### PR TITLE
Correct post date widget configuration

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -26,7 +26,7 @@ collections: # A list of collections the CMS should be able to edit
         options:
           - { label: "Dan Urbanowicz", value: "dan_urbanowicz" }
           - { label: "John Doe", value: "john_doe" }
-      - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD HH:MM:SS"}
+      - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD HH:mm:ss"}
       - {label: "Intro Paragraph", name: "intro_paragraph", widget: "markdown", required: false}
       - {label: "Body", name: "body", widget: "markdown", required: false}
       - {label: "Categories", name: "categories", widget: "string", required: false}


### PR DESCRIPTION
Change minutes and seconds indicators in datetime format string to lower case, indicating minutes (as opposed to months) and normal seconds (as opposed to fractional seconds). Fractional seconds allowed invalid numbers of seconds to be written, causing Jekyll build failure.

#7 
